### PR TITLE
Add tests for tasks

### DIFF
--- a/golang/pkg/rnr/task_nested_test.go
+++ b/golang/pkg/rnr/task_nested_test.go
@@ -1,0 +1,42 @@
+package rnr
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestNestedTask_Add(t *testing.T) {
+	nt := NewNestedTask("nested task test", 1)
+
+	for _, tn := range []string{"foo", "bar"} {
+		ct := newMockTask(tn)
+		if err := nt.Add(ct); err != nil {
+			t.Fatalf("unexpected error when adding task %s: %v", tn, err)
+		}
+	}
+
+	tn := "foo"
+	ct := newMockTask(tn)
+	if err := nt.Add(ct); err == nil {
+		t.Fatalf("expecting error when adding task with repeated name %s", tn)
+	}
+}
+
+func BenchmarkNestedTask_Add(b *testing.B) {
+	for _, n := range []int{1, 5, 10, 20, 30, 40, 50, 100, 1000, 10000} {
+		name := fmt.Sprintf("NestedTask - %6d children", n)
+		tasks := make([]*mockTask, 0, n)
+		for i := 0; i < n; i++ {
+			tasks = append(tasks, newMockTask(fmt.Sprintf("task: %6d", i)))
+		}
+
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				nt := NewNestedTask(name, 0)
+				for _, t := range tasks {
+					nt.Add(t)
+				}
+			}
+		})
+	}
+}

--- a/golang/pkg/rnr/task_nested_test.go
+++ b/golang/pkg/rnr/task_nested_test.go
@@ -40,3 +40,23 @@ func BenchmarkNestedTask_Add(b *testing.B) {
 		})
 	}
 }
+
+func TestNestedTask_GetChild(t *testing.T) {
+	nt := NewNestedTask("nested task test", 1)
+	ct1 := newMockTask("child 1")
+	ct2 := newMockTask("child 2")
+
+	nt.Add(ct1)
+	nt.Add(ct2)
+
+	if ct := nt.GetChild("child 1"); ct != ct1 {
+		t.Errorf("expecting GetChild to return %v, got %v", ct1, ct)
+	}
+	if ct := nt.GetChild("child 2"); ct != ct2 {
+		t.Errorf("expecting GetChild to return %v, got %v", ct2, ct)
+	}
+
+	if ct := nt.GetChild("foobar"); ct != nil {
+		t.Errorf("expecting GetChild to return nil, got %v", ct)
+	}
+}

--- a/golang/pkg/rnr/task_shell_test.go
+++ b/golang/pkg/rnr/task_shell_test.go
@@ -1,0 +1,11 @@
+package rnr
+
+import "testing"
+
+func TestShellTask_GetChild(t *testing.T) {
+	c := NewShellTask("shell task test", "").GetChild("foo")
+
+	if c != nil {
+		t.Fatalf("expecting GetChild to return nil, got %#v", c)
+	}
+}

--- a/golang/pkg/rnr/task_simple_callback.go
+++ b/golang/pkg/rnr/task_simple_callback.go
@@ -33,12 +33,14 @@ func NewCallbackTask(name string, callback CallbackFunc) *CallbackTask {
 
 // Poll synchronously calls the callback
 func (ct *CallbackTask) Poll() {
-	if taskSchedState(&ct.pb) != RUNNING {
+	if taskSchedState(&ct.pb) == RUNNING {
 		return
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
+
+	ct.pb.State = pb.TaskState_RUNNING
 	ret, err := ct.callback(ctx, ct)
 
 	if ret {

--- a/golang/pkg/rnr/task_simple_callback.go
+++ b/golang/pkg/rnr/task_simple_callback.go
@@ -33,14 +33,13 @@ func NewCallbackTask(name string, callback CallbackFunc) *CallbackTask {
 
 // Poll synchronously calls the callback
 func (ct *CallbackTask) Poll() {
-	if taskSchedState(&ct.pb) == RUNNING {
+	if taskSchedState(&ct.pb) != RUNNING {
 		return
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
-	ct.pb.State = pb.TaskState_RUNNING
 	ret, err := ct.callback(ctx, ct)
 
 	if ret {

--- a/golang/pkg/rnr/task_simple_callback_test.go
+++ b/golang/pkg/rnr/task_simple_callback_test.go
@@ -1,0 +1,22 @@
+package rnr
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCallbackTask_Poll(t *testing.T) {
+	var callbackCalled bool
+	fn := func(ctx context.Context, ct *CallbackTask) (bool, error) {
+		callbackCalled = true
+		return true, nil
+	}
+
+	ct := NewCallbackTask("callback test", fn)
+
+	ct.Poll()
+
+	if !callbackCalled {
+		t.Fatal("expecting callback function to be invoked")
+	}
+}

--- a/golang/pkg/rnr/task_simple_callback_test.go
+++ b/golang/pkg/rnr/task_simple_callback_test.go
@@ -2,6 +2,7 @@ package rnr
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/mplzik/rnr/golang/pkg/pb"
@@ -41,6 +42,37 @@ func TestCallbackTask_Poll(t *testing.T) {
 	if callsCount != 2 {
 		t.Errorf("expecting callback to be invoked twice, got %d invokations", callsCount)
 	}
+
+	t.Run("callback returns error", func(t *testing.T) {
+		var done bool
+		fn := func(ctx context.Context, ct *CallbackTask) (bool, error) {
+			return done, fmt.Errorf("done %t", done)
+		}
+		ct := NewCallbackTask("failing callback test", fn)
+
+		ct.Poll()
+
+		pbt := ct.Proto(nil)
+		if s := pbt.State; s != pb.TaskState_RUNNING {
+			t.Errorf("shouldn't update task state: %v", s)
+		}
+		if exp := "done false"; pbt.Message != exp {
+			t.Errorf("expectiing message to be %q, got %q", exp, pbt.Message)
+		}
+
+		ct.SetState(pb.TaskState_UNKNOWN)
+		done = true
+
+		ct.Poll()
+
+		pbt = ct.Proto(nil)
+		if s := pbt.State; s != pb.TaskState_FAILED {
+			t.Errorf("task state should be %v, got %v", pb.TaskState_FAILED, s)
+		}
+		if exp := "done true"; pbt.Message != exp {
+			t.Errorf("expectiing message to be %q, got %q", exp, pbt.Message)
+		}
+	})
 }
 
 func TestCallbackTask_GetChild(t *testing.T) {

--- a/golang/pkg/rnr/task_simple_callback_test.go
+++ b/golang/pkg/rnr/task_simple_callback_test.go
@@ -3,12 +3,18 @@ package rnr
 import (
 	"context"
 	"testing"
+
+	"github.com/mplzik/rnr/golang/pkg/pb"
 )
 
 func TestCallbackTask_Poll(t *testing.T) {
-	var callbackCalled bool
+	var callsCount int
 	fn := func(ctx context.Context, ct *CallbackTask) (bool, error) {
-		callbackCalled = true
+		callsCount++
+		if callsCount == 1 {
+			return false, nil
+		}
+
 		return true, nil
 	}
 
@@ -16,7 +22,31 @@ func TestCallbackTask_Poll(t *testing.T) {
 
 	ct.Poll()
 
-	if !callbackCalled {
+	if callsCount < 1 {
 		t.Fatal("expecting callback function to be invoked")
+	}
+
+	ct.Poll()
+
+	if callsCount > 1 {
+		t.Error("should have invoked the callback function once")
+	}
+
+	// changine state should call Poll again. This is something we
+	// *shouldn't* know about it.
+	ct.SetState(pb.TaskState_UNKNOWN)
+
+	ct.Poll()
+
+	if callsCount != 2 {
+		t.Errorf("expecting callback to be invoked twice, got %d invokations", callsCount)
+	}
+}
+
+func TestCallbackTask_GetChild(t *testing.T) {
+	c := NewCallbackTask("callback task test", nil).GetChild("foo")
+
+	if c != nil {
+		t.Fatalf("expecting GetChild to return nil, got %#v", c)
 	}
 }

--- a/golang/pkg/rnr/tasks_test.go
+++ b/golang/pkg/rnr/tasks_test.go
@@ -40,3 +40,31 @@ func TestTaskSchedState(t *testing.T) {
 		})
 	}
 }
+
+// Mock task useful for testing
+var _ Task = &mockTask{} // quick compiler check mockTask fulfills the interface
+
+type mockTask struct {
+	pbTask *pb.Task
+}
+
+// Not useful at the moment
+func (m *mockTask) Poll()                 {}
+func (m *mockTask) SetState(pb.TaskState) {}
+func (m *mockTask) GetChild(string) Task  { return nil }
+
+func (m *mockTask) Proto(updater func(*pb.Task)) *pb.Task {
+	if updater != nil {
+		updater(m.pbTask)
+	}
+
+	return m.pbTask
+}
+
+func newMockTask(name string) *mockTask {
+	return &mockTask{
+		pbTask: &pb.Task{
+			Name: name,
+		},
+	}
+}


### PR DESCRIPTION
This PR adds tests for the different `Task` implementations.

Note that it currently fails in the `CallbackTask.Poll` test, check the description in c34a7a7576f92e0b9c17f8d48aee1cdf9488b65e for additional information.