### PR TITLE
Remove empty state change messages from log.

### DIFF
--- a/golang/pkg/rnr/job.go
+++ b/golang/pkg/rnr/job.go
@@ -135,7 +135,10 @@ func (j *Job) Poll() {
 	// Calculate diff and post state changes
 	diff := taskDiff([]string{newProto.GetName()}, j.oldProto, newProto)
 
-	log.Printf("State changed: %s\n", strings.Join(diff, "\n"))
+	if len(diff) > 0 {
+		log.Printf("State changed: %s\n", strings.Join(diff, "\n"))
+	}
+
 	j.oldProto = proto.Clone(newProto).(*pb.Task)
 }
 


### PR DESCRIPTION
These were not really useful, mostly spamming the output.

Signed-off-by: Milan Plzik <milan.plzik@grafana.com>
