### PR TITLE
Remove extra task state rendered in the UI.

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -7047,7 +7047,6 @@ var $author$project$Main$viewTask = F2(
 						[
 							A2($author$project$Main$viewTaskHeadline, path, task)
 						])),
-					$elm$html$Html$text(task.state),
 					A2(
 					$elm$html$Html$ul,
 					_List_fromArray(

--- a/ui/src/Main.elm
+++ b/ui/src/Main.elm
@@ -100,7 +100,6 @@ viewTask path task =
     if List.length children > 0 then
       details [] ([ 
         summary [] [ viewTaskHeadline path task ], 
-        text task.state,
         ul [attribute "style" "list-style-type: none"] (List.map (\child -> li [] [viewTask (path ++ [child.name]) child]) children)
       ])
     else


### PR DESCRIPTION
When expanding the summary/detail section, a task state was printed
although it was already shown in the task's listbox. We don't need this
extra line.

Signed-off-by: Milan Plzik <milan.plzik@grafana.com>
