### PR TITLE
Sanitize NestedTask's scheduling behavior/implement fail-if-any/all.

### DIFF
--- a/golang/pkg/rnr/task_nested.go
+++ b/golang/pkg/rnr/task_nested.go
@@ -116,13 +116,10 @@ func (nt *NestedTask) Poll() {
 	nt.Proto(func(pb *pb.Task) { pb.Message = fmt.Sprintf("%d/%d", successCount, len(nt.children)) })
 
 	// Handle termination
-
-	if !nt.opts.CompleteAll {
-		if failedCount > 0 {
-			// Fail everything on a first failed task.
-			nt.SetState(pb.TaskState_FAILED)
-			return
-		}
+	if !nt.opts.CompleteAll && failedCount > 0 {
+		// Fail everything on a first failed task.
+		nt.SetState(pb.TaskState_FAILED)
+		return
 	}
 
 	if doneCount == len(nt.children) {

--- a/golang/pkg/rnr/task_nested.go
+++ b/golang/pkg/rnr/task_nested.go
@@ -85,8 +85,7 @@ func (nt *NestedTask) Poll() {
 	}
 
 	// Poll the running or changed tasks
-	for i := range nt.children {
-		child := nt.children[i]
+	for _, child := range nt.children {
 		pb := child.Proto(nil)
 		state := taskSchedState(pb)
 

--- a/golang/pkg/rnr/task_nested.go
+++ b/golang/pkg/rnr/task_nested.go
@@ -23,11 +23,11 @@ type NestedTaskOptions struct {
 	CompleteAll bool // if `true`, the NestedTask will attempt to run all tasks before transitioning to either SUCCEEDED or FAILED state.
 }
 
-func NewNestedTask(name string, opts *NestedTaskOptions) *NestedTask {
+func NewNestedTask(name string, opts NestedTaskOptions) *NestedTask {
 	ret := &NestedTask{}
 	ret.pb.Name = name
 	ret.oldState = make(map[*Task]pb.TaskState)
-	ret.opts = *opts
+	ret.opts = opts
 
 	// Sanitize opts
 	if ret.opts.Parallelism < 1 {

--- a/golang/pkg/rnr/task_nested_test.go
+++ b/golang/pkg/rnr/task_nested_test.go
@@ -3,10 +3,12 @@ package rnr
 import (
 	"fmt"
 	"testing"
+
+	"github.com/mplzik/rnr/golang/pkg/pb"
 )
 
 func TestNestedTask_Add(t *testing.T) {
-	nt := NewNestedTask("nested task test", 1)
+	nt := NewNestedTask("nested task test", &NestedTaskOptions{Parallelism: 1})
 
 	for _, tn := range []string{"foo", "bar"} {
 		ct := newMockTask(tn)
@@ -32,7 +34,7 @@ func BenchmarkNestedTask_Add(b *testing.B) {
 
 		b.Run(name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				nt := NewNestedTask(name, 0)
+				nt := NewNestedTask(name, &NestedTaskOptions{})
 				for _, t := range tasks {
 					nt.Add(t)
 				}
@@ -42,7 +44,7 @@ func BenchmarkNestedTask_Add(b *testing.B) {
 }
 
 func TestNestedTask_GetChild(t *testing.T) {
-	nt := NewNestedTask("nested task test", 1)
+	nt := NewNestedTask("nested task test", &NestedTaskOptions{Parallelism: 1})
 	ct1 := newMockTask("child 1")
 	ct2 := newMockTask("child 2")
 
@@ -59,4 +61,78 @@ func TestNestedTask_GetChild(t *testing.T) {
 	if ct := nt.GetChild("foobar"); ct != nil {
 		t.Errorf("expecting GetChild to return nil, got %v", ct)
 	}
+}
+
+func TestNestedTask_FailFirst(t *testing.T) {
+	nt := NewNestedTask("nested task test", &NestedTaskOptions{Parallelism: 1, CompleteAll: false})
+	ct1 := newMockFailingTask("child 1")
+	ct2 := newMockTask("child 2")
+
+	nt.Add(ct1)
+	nt.Add(ct2)
+	nt.SetState(pb.TaskState_RUNNING)
+
+	nt.Poll()
+
+	if ct1.pbTask.State != pb.TaskState_FAILED {
+		t.Errorf("expecting child 1 to be in failed state, got %v", ct1.pbTask.State)
+	}
+	if ct2.pbTask.State != pb.TaskState_PENDING {
+		t.Errorf("expecting child 2 to be in pending state, got %v", ct2.pbTask.State)
+	}
+	if nt.pb.State != pb.TaskState_FAILED {
+		t.Errorf("expecting child 2 to be in failed state, got %v", nt.pb.State)
+	}
+}
+
+func TestNestedTask_CompleteAllFail(t *testing.T) {
+	nt := NewNestedTask("nested task test", &NestedTaskOptions{Parallelism: 1, CompleteAll: true})
+	ct1 := newMockFailingTask("child 1")
+	ct2 := newMockTask("child 2")
+
+	nt.Add(ct1)
+	nt.Add(ct2)
+	nt.SetState(pb.TaskState_RUNNING)
+
+	nt.Poll()
+
+	if ct1.pbTask.State != pb.TaskState_FAILED {
+		t.Errorf("expecting child 1 to be in failed state, got %v", ct1.pbTask.State)
+	}
+	if ct2.pbTask.State != pb.TaskState_PENDING {
+		t.Errorf("expecting child 2 to be in pending state, got %v", ct2.pbTask.State)
+	}
+	if nt.pb.State != pb.TaskState_RUNNING {
+		t.Errorf("expecting child 2 to be in running state, got %v", nt.pb.State)
+	}
+
+	nt.Poll()
+
+	if ct1.pbTask.State != pb.TaskState_FAILED {
+		t.Errorf("expecting child 1 to be in failed state, got %v", ct1.pbTask.State)
+	}
+	if ct2.pbTask.State != pb.TaskState_SUCCESS {
+		t.Errorf("expecting child 2 to be in succeeded state, got %v", ct2.pbTask.State)
+	}
+	if nt.pb.State != pb.TaskState_FAILED {
+		t.Errorf("expecting child 2 to be in failed state, got %v", nt.pb.State)
+	}
+}
+
+func TestNestedTask_CompleteAllSuccess(t *testing.T) {
+	ct1 := newMockTask("child 1")
+	ct2 := newMockTask("child 2")
+	nt := NewNestedTask("nested task test", &NestedTaskOptions{Parallelism: 1, CompleteAll: true})
+
+	tasks := []Task{ct1, ct2, nt}
+
+	nt.Add(ct1)
+	nt.Add(ct2)
+	nt.SetState(pb.TaskState_RUNNING)
+
+	nt.Poll()
+	compareTaskStates(t, tasks, []pb.TaskState{pb.TaskState_SUCCESS, pb.TaskState_PENDING, pb.TaskState_RUNNING})
+
+	nt.Poll()
+	compareTaskStates(t, tasks, []pb.TaskState{pb.TaskState_SUCCESS, pb.TaskState_SUCCESS, pb.TaskState_SUCCESS})
 }

--- a/golang/pkg/rnr/task_nested_test.go
+++ b/golang/pkg/rnr/task_nested_test.go
@@ -68,21 +68,14 @@ func TestNestedTask_FailFirst(t *testing.T) {
 	ct1 := newMockFailingTask("child 1")
 	ct2 := newMockTask("child 2")
 
+	tasks := []Task{ct1, ct2, nt}
+
 	nt.Add(ct1)
 	nt.Add(ct2)
 	nt.SetState(pb.TaskState_RUNNING)
 
 	nt.Poll()
-
-	if ct1.pbTask.State != pb.TaskState_FAILED {
-		t.Errorf("expecting child 1 to be in failed state, got %v", ct1.pbTask.State)
-	}
-	if ct2.pbTask.State != pb.TaskState_PENDING {
-		t.Errorf("expecting child 2 to be in pending state, got %v", ct2.pbTask.State)
-	}
-	if nt.pb.State != pb.TaskState_FAILED {
-		t.Errorf("expecting child 2 to be in failed state, got %v", nt.pb.State)
-	}
+	compareTaskStates(t, tasks, []pb.TaskState{pb.TaskState_FAILED, pb.TaskState_PENDING, pb.TaskState_FAILED})
 }
 
 func TestNestedTask_CompleteAllFail(t *testing.T) {
@@ -90,33 +83,17 @@ func TestNestedTask_CompleteAllFail(t *testing.T) {
 	ct1 := newMockFailingTask("child 1")
 	ct2 := newMockTask("child 2")
 
+	tasks := []Task{ct1, ct2, nt}
+
 	nt.Add(ct1)
 	nt.Add(ct2)
 	nt.SetState(pb.TaskState_RUNNING)
 
 	nt.Poll()
-
-	if ct1.pbTask.State != pb.TaskState_FAILED {
-		t.Errorf("expecting child 1 to be in failed state, got %v", ct1.pbTask.State)
-	}
-	if ct2.pbTask.State != pb.TaskState_PENDING {
-		t.Errorf("expecting child 2 to be in pending state, got %v", ct2.pbTask.State)
-	}
-	if nt.pb.State != pb.TaskState_RUNNING {
-		t.Errorf("expecting child 2 to be in running state, got %v", nt.pb.State)
-	}
+	compareTaskStates(t, tasks, []pb.TaskState{pb.TaskState_FAILED, pb.TaskState_PENDING, pb.TaskState_RUNNING})
 
 	nt.Poll()
-
-	if ct1.pbTask.State != pb.TaskState_FAILED {
-		t.Errorf("expecting child 1 to be in failed state, got %v", ct1.pbTask.State)
-	}
-	if ct2.pbTask.State != pb.TaskState_SUCCESS {
-		t.Errorf("expecting child 2 to be in succeeded state, got %v", ct2.pbTask.State)
-	}
-	if nt.pb.State != pb.TaskState_FAILED {
-		t.Errorf("expecting child 2 to be in failed state, got %v", nt.pb.State)
-	}
+	compareTaskStates(t, tasks, []pb.TaskState{pb.TaskState_FAILED, pb.TaskState_SUCCESS, pb.TaskState_FAILED})
 }
 
 func TestNestedTask_CompleteAllSuccess(t *testing.T) {

--- a/golang/pkg/rnr/task_nested_test.go
+++ b/golang/pkg/rnr/task_nested_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestNestedTask_Add(t *testing.T) {
-	nt := NewNestedTask("nested task test", &NestedTaskOptions{Parallelism: 1})
+	nt := NewNestedTask("nested task test", NestedTaskOptions{})
 
 	for _, tn := range []string{"foo", "bar"} {
 		ct := newMockTask(tn)
@@ -34,7 +34,7 @@ func BenchmarkNestedTask_Add(b *testing.B) {
 
 		b.Run(name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				nt := NewNestedTask(name, &NestedTaskOptions{})
+				nt := NewNestedTask(name, NestedTaskOptions{})
 				for _, t := range tasks {
 					nt.Add(t)
 				}
@@ -44,7 +44,7 @@ func BenchmarkNestedTask_Add(b *testing.B) {
 }
 
 func TestNestedTask_GetChild(t *testing.T) {
-	nt := NewNestedTask("nested task test", &NestedTaskOptions{Parallelism: 1})
+	nt := NewNestedTask("nested task test", NestedTaskOptions{Parallelism: 1})
 	ct1 := newMockTask("child 1")
 	ct2 := newMockTask("child 2")
 
@@ -64,7 +64,7 @@ func TestNestedTask_GetChild(t *testing.T) {
 }
 
 func TestNestedTask_FailFirst(t *testing.T) {
-	nt := NewNestedTask("nested task test", &NestedTaskOptions{Parallelism: 1, CompleteAll: false})
+	nt := NewNestedTask("nested task test", NestedTaskOptions{Parallelism: 1, CompleteAll: false})
 	ct1 := newMockFailingTask("child 1")
 	ct2 := newMockTask("child 2")
 
@@ -86,7 +86,7 @@ func TestNestedTask_FailFirst(t *testing.T) {
 }
 
 func TestNestedTask_CompleteAllFail(t *testing.T) {
-	nt := NewNestedTask("nested task test", &NestedTaskOptions{Parallelism: 1, CompleteAll: true})
+	nt := NewNestedTask("nested task test", NestedTaskOptions{Parallelism: 1, CompleteAll: true})
 	ct1 := newMockFailingTask("child 1")
 	ct2 := newMockTask("child 2")
 
@@ -122,7 +122,7 @@ func TestNestedTask_CompleteAllFail(t *testing.T) {
 func TestNestedTask_CompleteAllSuccess(t *testing.T) {
 	ct1 := newMockTask("child 1")
 	ct2 := newMockTask("child 2")
-	nt := NewNestedTask("nested task test", &NestedTaskOptions{Parallelism: 1, CompleteAll: true})
+	nt := NewNestedTask("nested task test", NestedTaskOptions{Parallelism: 1, CompleteAll: true})
 
 	tasks := []Task{ct1, ct2, nt}
 

--- a/golang/pkg/rnr/tasks_test.go
+++ b/golang/pkg/rnr/tasks_test.go
@@ -45,13 +45,21 @@ func TestTaskSchedState(t *testing.T) {
 var _ Task = &mockTask{} // quick compiler check mockTask fulfills the interface
 
 type mockTask struct {
-	pbTask *pb.Task
+	pbTask     *pb.Task
+	finalState pb.TaskState
 }
 
 // Not useful at the moment
-func (m *mockTask) Poll()                 {}
-func (m *mockTask) SetState(pb.TaskState) {}
-func (m *mockTask) GetChild(string) Task  { return nil }
+func (m *mockTask) Poll() {
+	if m.pbTask.State != pb.TaskState_RUNNING {
+		return
+	}
+	m.SetState(m.finalState)
+}
+func (m *mockTask) SetState(state pb.TaskState) {
+	m.Proto(func(pb *pb.Task) { pb.State = state })
+}
+func (m *mockTask) GetChild(string) Task { return nil }
 
 func (m *mockTask) Proto(updater func(*pb.Task)) *pb.Task {
 	if updater != nil {
@@ -64,7 +72,33 @@ func (m *mockTask) Proto(updater func(*pb.Task)) *pb.Task {
 func newMockTask(name string) *mockTask {
 	return &mockTask{
 		pbTask: &pb.Task{
-			Name: name,
+			Name:  name,
+			State: pb.TaskState_PENDING,
 		},
+		finalState: pb.TaskState_SUCCESS,
+	}
+}
+
+func newMockFailingTask(name string) *mockTask {
+	return &mockTask{
+		pbTask: &pb.Task{
+			Name:  name,
+			State: pb.TaskState_PENDING,
+		},
+		finalState: pb.TaskState_FAILED,
+	}
+}
+
+func compareTaskStates(t *testing.T, tasks []Task, states []pb.TaskState) {
+	if len(tasks) != len(states) {
+		t.Errorf("`tasks` and `states` should have the same length (%d != %d)", len(tasks), len(states))
+	}
+
+	for i := range tasks {
+		task := tasks[i]
+		state := task.Proto(nil).State
+		if state != states[i] {
+			t.Errorf("Task `%s` expected to be in state %s, but was in %s instead.", task.Proto(nil).Name, states[i], state)
+		}
 	}
 }

--- a/golang/pkg/rnr/tasks_test.go
+++ b/golang/pkg/rnr/tasks_test.go
@@ -94,11 +94,11 @@ func compareTaskStates(t *testing.T, tasks []Task, states []pb.TaskState) {
 		t.Errorf("`tasks` and `states` should have the same length (%d != %d)", len(tasks), len(states))
 	}
 
-	for i := range tasks {
-		task := tasks[i]
-		state := task.Proto(nil).State
-		if state != states[i] {
-			t.Errorf("Task `%s` expected to be in state %s, but was in %s instead.", task.Proto(nil).Name, states[i], state)
+	for i, task := range tasks {
+		p := task.Proto(nil)
+		
+		if state := p.State; state != states[i] {
+			t.Errorf("Task `%s` expected to be in state %s, but was in %s instead.", p.Name, states[i], state)
 		}
 	}
 }


### PR DESCRIPTION
The NestedTask had originally attempted to complete as many child tasks
as posible, failing only after attempting to run complete of them. This
behavior doesn't suit well sequential tasks and thus, this PR explicitly
implements `CompleteAll` option which defaults to `false` (failing
immediately if any task fails) and if set to `true`, it will attempt to
run all the tasks before finalizing parent state.

This PR also adds more testing to NestedTask and reworks NestedTasks
scheduling -- particularly, it makes NestedTask first consolidate the
child task states and only then run `Poll()` on the selected ones.

Signed-off-by: Milan Plzik <milan.plzik@grafana.com>
