### PR TITLE
Implement custom Poll() for NestedTask.

### DIFF
--- a/golang/pkg/rnr/task_nested.go
+++ b/golang/pkg/rnr/task_nested.go
@@ -10,6 +10,8 @@ import (
 
 // Nested Task
 
+type NestedTaskCallback func(*NestedTask, *[]Task)
+
 type NestedTask struct {
 	pbMutex  sync.Mutex
 	pb       pb.Task
@@ -19,8 +21,9 @@ type NestedTask struct {
 }
 
 type NestedTaskOptions struct {
-	Parallelism int  // the number of tasks to run in parallel; defaults to 1
-	CompleteAll bool // if `true`, the NestedTask will attempt to run all tasks before transitioning to either SUCCEEDED or FAILED state.
+	Poll        NestedTaskCallback // a callback called each time a Poll() on NestedTask is called.
+	Parallelism int                // the number of tasks to run in parallel; defaults to 1.
+	CompleteAll bool               // if `true`, the NestedTask will attempt to run all tasks before transitioning to either SUCCEEDED or FAILED state.
 }
 
 func NewNestedTask(name string, opts NestedTaskOptions) *NestedTask {
@@ -56,6 +59,10 @@ func (nt *NestedTask) Poll() {
 
 	if taskSchedState(nt.Proto(nil)) != RUNNING {
 		return
+	}
+
+	if nt.opts.Poll != nil {
+		nt.opts.Poll(nt, &nt.children)
 	}
 
 	running := 0

--- a/golang/pkg/rnr/task_nested_test.go
+++ b/golang/pkg/rnr/task_nested_test.go
@@ -113,3 +113,38 @@ func TestNestedTask_CompleteAllSuccess(t *testing.T) {
 	nt.Poll()
 	compareTaskStates(t, tasks, []pb.TaskState{pb.TaskState_SUCCESS, pb.TaskState_SUCCESS, pb.TaskState_SUCCESS})
 }
+
+func TestNestedTask_CallbackInvoked(t *testing.T) {
+	childrenAdded := 0
+	nt := NewNestedTask("nested task test", NestedTaskOptions{
+		Parallelism: 1,
+		CompleteAll: true,
+		Poll: func(nt *NestedTask, children *[]Task) {
+			childName := fmt.Sprintf("callback-added child %d", childrenAdded)
+			nt.Add(newMockTask(childName))
+			childrenAdded += 1
+		},
+	})
+
+	nt.SetState(pb.TaskState_PENDING)
+	nt.Poll()
+	if childrenAdded != 0 {
+		t.Errorf("callback shouldn't be invoked for non-RUNNING nested task!")
+	}
+
+	nt.SetState(pb.TaskState_RUNNING)
+	nt.Poll()
+	if childrenAdded != 1 {
+		t.Errorf("nested task callback was not invoked for running task!")
+	}
+	if len(nt.children) != 1 {
+		t.Errorf("expected 1 child, got %d", len(nt.children))
+	}
+
+	nt.SetState(pb.TaskState_RUNNING)
+	nt.Poll()
+	fmt.Println(nt.children[1].Proto(nil).Name)
+	if len(nt.children) != 2 {
+		t.Errorf("expected 2 children, got %d", len(nt.children))
+	}
+}


### PR DESCRIPTION
Up until now, `NestedTask`'s Poll() only performed a simple scheduling
function, not allowing for any customization. This PR adds a support for
custom callbacks that are (to some extent) able to modify the children
of NestedTasks, making it possible to update the children in the
real-time to reflect the real-world situations.

Signed-off-by: Milan Plzik <milan.plzik@grafana.com>
