### PR TITLE
Remove extraneous `go Poll()` call.

### DIFF
--- a/golang/pkg/rnr/task_simple_callback.go
+++ b/golang/pkg/rnr/task_simple_callback.go
@@ -73,9 +73,6 @@ func (ct *CallbackTask) Proto(updater func(*pb.Task)) *pb.Task {
 
 func (ct *CallbackTask) SetState(state pb.TaskState) {
 	ct.Proto(func(pb *pb.Task) { pb.State = state })
-
-	// An additional call to let the task know about state change
-	go ct.Poll()
 }
 
 func (ct *CallbackTask) GetChild(name string) Task {


### PR DESCRIPTION
This was previously used to trigger a call to Poll() once the task's
state has changed. Since there's already another mechanism to do this
(`oldState` handling), we don't need this anymore.

Signed-off-by: Milan Plzik <milan.plzik@grafana.com>
