### PR TITLE
Make Job context aware

### DIFF
--- a/golang/pkg/rnr/job.go
+++ b/golang/pkg/rnr/job.go
@@ -14,9 +14,6 @@ import (
 	proto "google.golang.org/protobuf/proto"
 )
 
-// Job polling interval
-var pollInterval = 5 * time.Second
-
 var (
 	ErrJobNotRunning     = errors.New("job is not running")
 	ErrJobAlreadyStarted = errors.New("job was already started")
@@ -162,7 +159,7 @@ func (j *Job) TaskRequest(r *pb.TaskRequest) error {
 func (j *Job) Err() error { return j.err }
 
 // Start is a shortcut for setting the root task to "running" state.
-func (j *Job) Start(ctx context.Context) error {
+func (j *Job) Start(ctx context.Context, pollInterval time.Duration) error {
 	if j.done != nil {
 		return ErrJobAlreadyStarted
 	}

--- a/golang/pkg/rnr/job.go
+++ b/golang/pkg/rnr/job.go
@@ -1,6 +1,7 @@
 package rnr
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"sort"
@@ -12,40 +13,26 @@ import (
 	proto "google.golang.org/protobuf/proto"
 )
 
+// Job polling interval
+var pollInterval = 5 * time.Second
+
 type Job struct {
 	pbMutex  sync.Mutex
 	job      pb.Job
 	root     Task
-	stop     chan struct{}
 	oldProto *pb.Task
+	err      error
 }
 
 func NewJob(root Task) *Job {
-	ret := &Job{
+	return &Job{
 		job: pb.Job{
 			Version: 1,
 			Uuid:    "1235abcdef",
 			Root:    nil,
 		},
 		root: root,
-		stop: make(chan struct{}),
 	}
-
-	go func() {
-		ticker := time.NewTicker(5 * time.Second)
-		for exit := false; !exit; {
-			select {
-			case _, ok := <-ret.stop:
-				if !ok {
-					exit = true
-				}
-			case <-ticker.C:
-				ret.Poll()
-			}
-		}
-	}()
-
-	return ret
 }
 
 func (j *Job) Proto(updater func(*pb.Job)) *pb.Job {
@@ -128,7 +115,7 @@ func taskDiff(path []string, old *pb.Task, new *pb.Task) []string {
 	return ret
 }
 
-func (j *Job) Poll() {
+func (j *Job) Poll(ctx context.Context) {
 	j.root.Poll()
 
 	newProto := j.root.Proto(nil)
@@ -164,7 +151,35 @@ func (j *Job) TaskRequest(r *pb.TaskRequest) error {
 	return nil
 }
 
+// Err returns whatever error might have happened after Start.
+func (j *Job) Err() error { return j.err }
+
 // Start is a shortcut for setting the root task to "running" state.
-func (j *Job) Start() {
+func (j *Job) Start(ctx context.Context) func() {
 	j.root.SetState(pb.TaskState_RUNNING)
+
+	stopCh := make(chan struct{})
+	stopFn := func() { close(stopCh) }
+
+	go func() {
+		ticker := time.NewTicker(pollInterval)
+
+		for {
+			select {
+			case <-stopCh:
+				// job was stopped by calling stopFn
+				return
+
+			case <-ctx.Done():
+				// job stopp due to context being done (e.g. cancelled or timed out)
+				j.err = ctx.Err()
+				return
+
+			case <-ticker.C:
+				j.Poll(ctx)
+			}
+		}
+	}()
+
+	return stopFn
 }

--- a/golang/pkg/rnr/job.go
+++ b/golang/pkg/rnr/job.go
@@ -195,3 +195,6 @@ func (j *Job) Stop() error {
 	j.done = nil
 	return nil
 }
+
+// Wait waits for the Job to finish.
+func (j *Job) Wait() <-chan struct{} { return j.done }

--- a/golang/pkg/rnr/job.go
+++ b/golang/pkg/rnr/job.go
@@ -163,6 +163,7 @@ func (j *Job) Start(ctx context.Context) func() {
 
 	go func() {
 		ticker := time.NewTicker(pollInterval)
+		defer ticker.Stop()
 
 		for {
 			select {

--- a/golang/pkg/rnr/job_test.go
+++ b/golang/pkg/rnr/job_test.go
@@ -1,0 +1,67 @@
+package rnr_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/mplzik/rnr/golang/pkg/pb"
+	"github.com/mplzik/rnr/golang/pkg/rnr"
+)
+
+var _ rnr.Task = &task{}
+
+type task struct {
+	pollFn func()
+}
+
+func (t *task) Poll()                         { t.pollFn() }
+func (t *task) SetState(pb.TaskState)         {}
+func (t *task) Proto(func(*pb.Task)) *pb.Task { return nil }
+func (*task) GetChild(string) rnr.Task        { return nil }
+
+func TestJob(t *testing.T) {
+	var pollCount int
+
+	task := &task{
+		pollFn: func() {
+			pollCount++
+			t.Logf("poll %02d", pollCount)
+		},
+	}
+
+	j := rnr.NewJob(task)
+
+	ctx := context.Background()
+
+	var err error
+
+	if err = j.Start(ctx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err = j.Start(ctx); !errors.Is(err, rnr.ErrJobAlreadyStarted) {
+		t.Fatalf("expecting ErrJobAlreadyStarted, got %v", err)
+	}
+
+	var stopErr error
+
+	go func() {
+		for {
+			if pollCount == 5 {
+				stopErr = j.Stop()
+				break
+			}
+		}
+	}()
+
+	<-j.Wait()
+
+	if stopErr != nil {
+		t.Fatalf("unexpected error: %v", stopErr)
+	}
+
+	if err := j.Stop(); !errors.Is(err, rnr.ErrJobNotRunning) {
+		t.Fatalf("expecting rnr.ErrJobNotRunning, got %v", err)
+	}
+}

--- a/golang/pkg/rnr/job_test.go
+++ b/golang/pkg/rnr/job_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/mplzik/rnr/golang/pkg/pb"
 	"github.com/mplzik/rnr/golang/pkg/rnr"
@@ -36,11 +37,11 @@ func TestJob(t *testing.T) {
 
 	var err error
 
-	if err = j.Start(ctx); err != nil {
+	if err = j.Start(ctx, 5*time.Millisecond); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if err = j.Start(ctx); !errors.Is(err, rnr.ErrJobAlreadyStarted) {
+	if err = j.Start(ctx, time.Millisecond); !errors.Is(err, rnr.ErrJobAlreadyStarted) {
 		t.Fatalf("expecting ErrJobAlreadyStarted, got %v", err)
 	}
 


### PR DESCRIPTION
Here we're changing the Job API to make it context aware while also giving the calling user the possibility of gracefully stopping the go routine that manages polling the job and its tasks.

The biggest change is in the Job.Start method that now accepts a context.Context as its main parameter, and returns a signal function for the caller to execute when manually stopping the job.

With these changes now managing jobs become:

```go
job := rnr.NewJob(task)
if err := job.Start(context.Background()); err != nil {
    log.Fatal("failed to start job:", err)
}

// Stop after 10 seconds
go func() {
    time.Sleep(10 * time.Second)
    job.Stop()
}()

// wait for job to finish
<-job.Wait()

// check if there was an error
if err := job.Err(); err != nil {
    log.Fatal("job error:", err)
}
```

Manually calling `Job.Stop` doesn't seem like the most interesting option, however, by making it context aware we can also control the polling loop. In the following example, the job can be cancelled by the user pressing `^C` or after 10 seconds, whatever happens first:

```go
ctx, stopNotify := signal.NotifyContext(context.Background(), os.Interrupt)
defer stopNotify()
ctx, stopTimeout := context.WithTimeout(ctx, 10 * time.Second)
defer stopTimeout()

job := rnr.NewJob(task)
job.Start(ctx)
<-job.Wait()

log.Printf("job finished with: %v", job.Err())
```

It is worth mentioning that both `Stop` and `Start` return the following errors:

* `Job.Stop` returns `ErrJobNotRunning` when calling `Stop` before calling `Start`.
* `Job.Start` returns `ErrJobAlreadyStarted` when calling `Start` more than once, or after a job was stopped; yes, jobs are one use only.

