### PR TITLE
Make `Task` context aware

### DIFF
--- a/golang/pkg/rnr/job.go
+++ b/golang/pkg/rnr/job.go
@@ -120,7 +120,7 @@ func taskDiff(path []string, old *pb.Task, new *pb.Task) []string {
 }
 
 func (j *Job) Poll(ctx context.Context) {
-	j.root.Poll()
+	j.root.Poll(ctx)
 
 	newProto := j.root.Proto(nil)
 	// Calculate diff and post state changes

--- a/golang/pkg/rnr/job_test.go
+++ b/golang/pkg/rnr/job_test.go
@@ -13,10 +13,10 @@ import (
 var _ rnr.Task = &task{}
 
 type task struct {
-	pollFn func()
+	pollFn func(context.Context)
 }
 
-func (t *task) Poll()                         { t.pollFn() }
+func (t *task) Poll(ctx context.Context)      { t.pollFn(ctx) }
 func (t *task) SetState(pb.TaskState)         {}
 func (t *task) Proto(func(*pb.Task)) *pb.Task { return nil }
 func (*task) GetChild(string) rnr.Task        { return nil }
@@ -25,7 +25,7 @@ func TestJob(t *testing.T) {
 	var pollCount int
 
 	task := &task{
-		pollFn: func() {
+		pollFn: func(context.Context) {
 			pollCount++
 			t.Logf("poll %02d", pollCount)
 		},

--- a/golang/pkg/rnr/task_nested.go
+++ b/golang/pkg/rnr/task_nested.go
@@ -9,6 +9,7 @@ import (
 )
 
 // Nested Task
+var _ Task = &NestedTask{}
 
 type NestedTaskCallback func(*NestedTask, *[]Task)
 

--- a/golang/pkg/rnr/task_nested.go
+++ b/golang/pkg/rnr/task_nested.go
@@ -1,6 +1,7 @@
 package rnr
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -56,7 +57,7 @@ func (nt *NestedTask) Add(task Task) error {
 	return nil
 }
 
-func (nt *NestedTask) Poll() {
+func (nt *NestedTask) Poll(ctx context.Context) {
 
 	if taskSchedState(nt.Proto(nil)) != RUNNING {
 		return
@@ -100,7 +101,7 @@ func (nt *NestedTask) Poll() {
 		// Poll a task iff it's running or it has its state changed recently
 		if state == RUNNING || pb.State != nt.oldState[child] {
 			nt.oldState[child] = pb.State
-			child.Poll()
+			child.Poll(ctx)
 		}
 
 	}

--- a/golang/pkg/rnr/task_shell.go
+++ b/golang/pkg/rnr/task_shell.go
@@ -1,6 +1,7 @@
 package rnr
 
 import (
+	"context"
 	"os/exec"
 	"sync"
 
@@ -35,13 +36,16 @@ func NewShellTask(name, cmd string, args ...string) *ShellTask {
 	return ret
 }
 
-func (ct *ShellTask) Poll() {
+func (ct *ShellTask) Poll(ctx context.Context) {
 	if ct.cmd.Process == nil {
 		// Not yet started, let's launch it first
 		go func() { ct.err <- ct.cmd.Run() }()
 		ct.pb.Message = "Started"
 	}
 
+	// TODO here we should probably do something when the context is
+	// cancelled, by killing the process. In that case we need to
+	// define how are we going to handle the error.
 	select {
 	default:
 		// still running

--- a/golang/pkg/rnr/task_shell.go
+++ b/golang/pkg/rnr/task_shell.go
@@ -9,6 +9,7 @@ import (
 )
 
 // Shell Task
+var _ Task = &ShellTask{}
 
 type ShellTask struct {
 	pbMutex  sync.Mutex

--- a/golang/pkg/rnr/task_shell_test.go
+++ b/golang/pkg/rnr/task_shell_test.go
@@ -1,6 +1,84 @@
 package rnr
 
-import "testing"
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/mplzik/rnr/golang/pkg/pb"
+)
+
+func TestMain(m *testing.M) {
+	var (
+		runTests = flag.Bool("run-tests", true, "whether to run the tests")
+		exitCode = flag.Int("exit-code", 0, "exit code when not running the tests")
+		sleep    = flag.Duration("sleep", 0*time.Second, "how long to sleep to simulate activity")
+	)
+
+	flag.Parse()
+
+	if *runTests {
+		os.Exit(m.Run())
+	}
+
+	t := time.NewTicker(10 * time.Millisecond)
+	a := time.After(*sleep)
+
+	var done bool
+
+	for !done {
+		select {
+		case <-a:
+			fmt.Println("DONE AFTER", *sleep)
+			done = true
+		case <-t.C:
+			fmt.Println("TICK")
+		}
+	}
+
+	os.Exit(*exitCode)
+}
+
+func TestShellTask(t *testing.T) {
+	run := func(ctx context.Context, exitCode int, expectedState pb.TaskState, sleep time.Duration) {
+		t.Helper()
+
+		task := NewShellTask("foo", os.Args[0], "-run-tests=false", "-exit-code", strconv.Itoa(exitCode), "-sleep", sleep.String())
+
+		for {
+			state := task.Proto(nil).State
+			if state == pb.TaskState_SUCCESS || state == pb.TaskState_FAILED {
+				break
+			}
+			task.Poll(ctx)
+			time.Sleep(50 * time.Millisecond)
+		}
+
+		if state := task.Proto(nil).State; state != expectedState {
+			t.Fatalf("expecting %v state, got %v", expectedState, state)
+		}
+
+		pb := task.Proto(nil)
+		t.Logf("task in state %v with message %q", pb.State, pb.Message)
+	}
+
+	ctx := context.Background()
+
+	run(ctx, 0, pb.TaskState_SUCCESS, 0)
+	run(ctx, 1, pb.TaskState_FAILED, 0)
+
+	ctx2, cancel := context.WithCancel(ctx)
+	cancel() // manually cancel the context
+	run(ctx2, 0, pb.TaskState_FAILED, 5*time.Second)
+
+	ctx3, cancel := context.WithCancel(ctx)
+	cancel() // manually cancel the context
+	run(ctx3, 1, pb.TaskState_FAILED, 5*time.Second)
+}
 
 func TestShellTask_GetChild(t *testing.T) {
 	c := NewShellTask("shell task test", "").GetChild("foo")

--- a/golang/pkg/rnr/task_simple_callback.go
+++ b/golang/pkg/rnr/task_simple_callback.go
@@ -35,7 +35,7 @@ func NewCallbackTask(name string, callback CallbackFunc) *CallbackTask {
 }
 
 // Poll synchronously calls the callback
-func (ct *CallbackTask) Poll() {
+func (ct *CallbackTask) Poll(ctx context.Context) {
 	if (taskSchedState(&ct.pb) != RUNNING) && (ct.oldState == ct.pb.GetState()) {
 		return
 	}

--- a/golang/pkg/rnr/task_simple_callback.go
+++ b/golang/pkg/rnr/task_simple_callback.go
@@ -40,8 +40,10 @@ func (ct *CallbackTask) Poll(ctx context.Context) {
 		return
 	}
 
+	// TODO should we call the callback if the context was done?
+
 	ct.oldState = ct.pb.GetState()
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 
 	ret, err := ct.callback(ctx, ct)

--- a/golang/pkg/rnr/task_simple_callback.go
+++ b/golang/pkg/rnr/task_simple_callback.go
@@ -12,6 +12,7 @@ import (
 type CallbackFunc func(context.Context, *CallbackTask) (bool, error)
 
 // CallbackTask
+var _ Task = &CallbackTask{}
 
 // CallbackTask implements a task with synchronously called callback.
 // It returns a boolean indicating whether to transition into a final state and an error in case an error has happened. These values are used to best-effort-update the task's protobuf. If (false, nil) is supplied, the task state will be left untouched

--- a/golang/pkg/rnr/task_simple_callback_test.go
+++ b/golang/pkg/rnr/task_simple_callback_test.go
@@ -94,6 +94,24 @@ func TestCallbackTask_Poll(t *testing.T) {
 			t.Errorf("expectiing message to be %q, got %q", exp, pbt.Message)
 		}
 	})
+
+	t.Run("context", func(t *testing.T) {
+		type keyType int
+		key := keyType(1024)
+		val := 42
+		ctx := context.WithValue(context.Background(), key, val)
+
+		fn := func(ctx context.Context, ct *CallbackTask) (bool, error) {
+			if got := ctx.Value(key); got != val {
+				t.Fatalf("expecting context key %T(%#[1]v) with value %v, got %v", key, val, got)
+			}
+			return true, nil
+		}
+
+		ct := NewCallbackTask("foo", fn)
+		ct.SetState(pb.TaskState_RUNNING)
+		ct.Poll(ctx)
+	})
 }
 
 func TestCallbackTask_GetChild(t *testing.T) {

--- a/golang/pkg/rnr/task_simple_callback_test.go
+++ b/golang/pkg/rnr/task_simple_callback_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestCallbackTask_Poll(t *testing.T) {
+	ctx := context.Background()
+
 	var callsCount int
 	fn := func(ctx context.Context, ct *CallbackTask) (bool, error) {
 		callsCount++
@@ -22,7 +24,7 @@ func TestCallbackTask_Poll(t *testing.T) {
 	ct := NewCallbackTask("callback test", fn)
 
 	{ // shouldn't call callback because task isn't running
-		ct.Poll()
+		ct.Poll(ctx)
 
 		if callsCount != 0 {
 			t.Fatalf("callback task shouldn't have been called because it's not running (%d calls)", callsCount)
@@ -32,7 +34,7 @@ func TestCallbackTask_Poll(t *testing.T) {
 	{ // should call the callback when task is running without changing task state
 		ct.SetState(pb.TaskState_RUNNING)
 
-		ct.Poll()
+		ct.Poll(ctx)
 
 		if callsCount < 1 {
 			t.Fatal("expecting callback function to be invoked")
@@ -43,7 +45,7 @@ func TestCallbackTask_Poll(t *testing.T) {
 	}
 
 	{ // should change state when callback is done
-		ct.Poll()
+		ct.Poll(ctx)
 
 		if callsCount != 2 {
 			t.Errorf("should have invoked the callback function twice (%d calls)", callsCount)
@@ -55,7 +57,7 @@ func TestCallbackTask_Poll(t *testing.T) {
 
 	{ // shouldn't call the callback
 		oldCount := callsCount
-		ct.Poll()
+		ct.Poll(ctx)
 
 		if callsCount != oldCount {
 			t.Errorf("expecting callback to be invoked %d times, got %d invokations", oldCount, callsCount)
@@ -70,7 +72,7 @@ func TestCallbackTask_Poll(t *testing.T) {
 		ct := NewCallbackTask("failing callback test", fn)
 
 		ct.SetState(pb.TaskState_RUNNING)
-		ct.Poll()
+		ct.Poll(ctx)
 
 		pbt := ct.Proto(nil)
 		if s := pbt.State; s != pb.TaskState_RUNNING {
@@ -82,7 +84,7 @@ func TestCallbackTask_Poll(t *testing.T) {
 
 		done = true
 
-		ct.Poll()
+		ct.Poll(ctx)
 
 		pbt = ct.Proto(nil)
 		if s := pbt.State; s != pb.TaskState_FAILED {

--- a/golang/pkg/rnr/tasks.go
+++ b/golang/pkg/rnr/tasks.go
@@ -1,6 +1,8 @@
 package rnr
 
 import (
+	"context"
+
 	"github.com/mplzik/rnr/golang/pkg/pb"
 )
 
@@ -30,7 +32,7 @@ func taskSchedState(pbt *pb.Task) TaskState {
 
 // Task is a generic interface for pollable tasks
 type Task interface {
-	Poll()
+	Poll(ctx context.Context)
 	Proto(updater func(*pb.Task)) *pb.Task
 	SetState(pb.TaskState)
 	GetChild(name string) Task

--- a/golang/pkg/rnr/tasks_test.go
+++ b/golang/pkg/rnr/tasks_test.go
@@ -1,6 +1,7 @@
 package rnr
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -51,7 +52,7 @@ type mockTask struct {
 }
 
 // Not useful at the moment
-func (m *mockTask) Poll() {
+func (m *mockTask) Poll(ctx context.Context) {
 	m.pollCount += 1
 	if m.pbTask.State != pb.TaskState_RUNNING {
 		return


### PR DESCRIPTION
Implements #6.

This is a continuation of #18, where we made `Job` context aware. At the time of opening this PR we have the following situation:

* `NestedTask` only passes down the context to its children. It doesn't check in its state if the context is done or not; perhaps we could make it that it only calls its children `Poll` method only if the context is not done.
* `ShellTask` ~~is ignoring the context completely. We could change it to either create the command using [`exec.CommandContext`](https://pkg.go.dev/os/exec#CommandContext) and ignore the context on each polling iteration, or checking if the context is done when polling and call [`Process.Kill`](https://pkg.go.dev/os#Process.Kill) on the running process~~ now stops the process if the context is cancelled.
* `CallbackTask` ~~is passing a custom context with a 1s timeout when calling the callback function. I believe it would be better if we just pass the context directly or if we add the timeout but using the given context as its parent instead of a new `context.Background`~~ now it passes down the `Poll` context argument. In addition, the timeout could be configurable instead of hardcoded. I'm still not sure if the callback should be called if the context was done 🤔 

Opening as a draft while we discussed the points mentioned above.