### PR TITLE
Implement async task and make polling mandatory.

### DIFF
--- a/golang/pkg/rnr/task_async.go
+++ b/golang/pkg/rnr/task_async.go
@@ -1,0 +1,73 @@
+package rnr
+
+import (
+	"context"
+	"sync"
+
+	"github.com/mplzik/rnr/golang/pkg/pb"
+	proto "google.golang.org/protobuf/proto"
+)
+
+type AsyncFunc func(context.Context, *AsyncTask)
+
+type AsyncTask struct {
+	pbMutex   sync.Mutex
+	pb        pb.Task
+	bgTask    AsyncFunc
+	parentCtx context.Context
+	ctx       context.Context
+	cancel    context.CancelFunc
+
+	// If set to `true`, the task will keep on running even after switching to SUCCESS state, making it a sort-of background task.
+	runsInSuccess bool
+}
+
+func NewAsyncTask(name string, ctx context.Context, runsInSuccess bool, bgTask AsyncFunc) *AsyncTask {
+	ret := &AsyncTask{}
+	ret.pb.Name = name
+	ret.bgTask = bgTask
+	ret.parentCtx = ctx
+	ret.ctx = nil
+	ret.cancel = nil
+	ret.runsInSuccess = runsInSuccess
+
+	return ret
+}
+
+// Task is a generic interface for pollable tasks
+func (bt *AsyncTask) Poll() {
+	state := bt.Proto(nil)
+
+	if state.State == pb.TaskState_RUNNING || (bt.runsInSuccess && state.State == pb.TaskState_SUCCESS) {
+		if bt.ctx == nil {
+			bt.ctx, bt.cancel = context.WithCancel(bt.parentCtx)
+			go bt.bgTask(bt.ctx, bt)
+		}
+	} else {
+		if bt.ctx != nil {
+			bt.cancel()
+			bt.ctx = nil
+			bt.cancel = nil
+		}
+	}
+}
+
+func (bt *AsyncTask) Proto(updater func(*pb.Task)) *pb.Task {
+	bt.pbMutex.Lock()
+	defer bt.pbMutex.Unlock()
+
+	if updater != nil {
+		updater(&bt.pb)
+	}
+	ret := proto.Clone(&bt.pb).(*pb.Task)
+
+	return ret
+}
+
+func (bt *AsyncTask) SetState(state pb.TaskState) {
+	bt.Proto(func(pb *pb.Task) { pb.State = state })
+}
+
+func (bt *AsyncTask) GetChild(name string) Task {
+	return nil
+}

--- a/golang/pkg/rnr/task_async_test.go
+++ b/golang/pkg/rnr/task_async_test.go
@@ -1,0 +1,113 @@
+package rnr
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mplzik/rnr/golang/pkg/pb"
+)
+
+const tick = 10 * time.Millisecond
+
+func TestAsyncTask_Lifecycle(t *testing.T) {
+	running := false
+	at := NewAsyncTask("Test async task", context.Background(), false, func(ctx context.Context, at *AsyncTask) {
+		running = true
+		select {
+		case <-ctx.Done():
+			running = false
+		}
+		at.Proto(func(t *pb.Task) {
+			t.State = pb.TaskState_SUCCESS
+		})
+	})
+
+	at.Poll()
+	time.Sleep(tick)
+	if running != false {
+		t.Errorf("async task expected not running was found running")
+	}
+
+	at.Proto(func(t *pb.Task) {
+		t.State = pb.TaskState_RUNNING
+	})
+	at.Poll()
+	time.Sleep(tick)
+	if running != true {
+		t.Errorf("async task expected running was found not running")
+	}
+
+	at.Proto(func(t *pb.Task) {
+		t.State = pb.TaskState_SUCCESS
+	})
+	at.Poll()
+	time.Sleep(tick)
+	if running != false {
+		t.Errorf("async task expected not running anymore was found running")
+	}
+}
+
+func TestAsyncTask_BackgroundLifecycle(t *testing.T) {
+	running := false
+	at := NewAsyncTask("Test async task", context.Background(), true, func(ctx context.Context, at *AsyncTask) {
+		running = true
+		select {
+		case <-ctx.Done():
+			running = false
+		}
+		at.Proto(func(t *pb.Task) {
+			t.State = pb.TaskState_SUCCESS
+		})
+	})
+
+	at.Poll()
+	time.Sleep(tick)
+	if running != false {
+		t.Errorf("async task expected not running was found running")
+	}
+
+	at.Proto(func(t *pb.Task) {
+		t.State = pb.TaskState_RUNNING
+	})
+	at.Poll()
+	time.Sleep(tick)
+	if running != true {
+		t.Errorf("async task expected running was found not running")
+	}
+
+	at.Proto(func(t *pb.Task) {
+		t.State = pb.TaskState_SUCCESS
+	})
+	at.Poll()
+	time.Sleep(tick)
+	if running != true {
+		t.Errorf("async task expected to be running in SUCCESS was found not running")
+	}
+
+	at.Proto(func(t *pb.Task) {
+		t.State = pb.TaskState_FAILED
+	})
+	at.Poll()
+	time.Sleep(tick)
+	if running != false {
+		t.Errorf("async task expected not running anymore was found running")
+	}
+}
+
+func TestAsyncTask_EarlyExit(t *testing.T) {
+	at := NewAsyncTask("Test async task", context.Background(), false, func(ctx context.Context, at *AsyncTask) {
+	})
+
+	at.Proto(func(t *pb.Task) {
+		t.State = pb.TaskState_RUNNING
+	})
+	at.Poll()
+	time.Sleep(tick)
+
+	at.Proto(func(t *pb.Task) {
+		t.State = pb.TaskState_SUCCESS
+	})
+	at.Poll()
+	time.Sleep(10 * time.Millisecond)
+}

--- a/golang/pkg/rnr/task_simple_callback_test.go
+++ b/golang/pkg/rnr/task_simple_callback_test.go
@@ -53,12 +53,12 @@ func TestCallbackTask_Poll(t *testing.T) {
 		}
 	}
 
-	{ // shouldn't call the callback
+	{ // should call the callback
 		oldCount := callsCount
 		ct.Poll()
 
-		if callsCount != oldCount {
-			t.Errorf("expecting callback to be invoked %d times, got %d invokations", oldCount, callsCount)
+		if callsCount != oldCount+1 {
+			t.Errorf("expecting callback to be invoked %d times, got %d invocations", oldCount, callsCount)
 		}
 	}
 


### PR DESCRIPTION
Instead of invoking a callback periodically, an Async task launches a
goroutine with a context, which should define its lifetime. This task
can communicate its state by updating task's protobuf using the
`Proto()` function.

Moreover, this PR also updates `NestedTask` to always call `Poll()` of its
children, regardless of the task state.

Signed-off-by: Milan Plzik <milan.plzik@grafana.com>
