### PR TITLE
Refactor `rnr` to be more functional.

### DIFF
--- a/golang/pkg/rnr/job.go
+++ b/golang/pkg/rnr/job.go
@@ -22,13 +22,13 @@ var (
 type Job struct {
 	pbMutex  sync.Mutex
 	job      pb.Job
-	root     Task
+	root     *Task
 	oldProto *pb.Task
 	err      error
 	done     chan struct{}
 }
 
-func NewJob(root Task) *Job {
+func NewJob(root *Task) *Job {
 	return &Job{
 		job: pb.Job{
 			Version: 1,
@@ -48,7 +48,8 @@ func (j *Job) Proto(updater func(*pb.Job)) *pb.Job {
 	}
 
 	ret := proto.Clone(&j.job).(*pb.Job)
-	ret.Root = j.root.Proto(nil)
+	tasksData := j.root.Proto(nil)
+	ret.Root = tasksData
 
 	return ret
 }
@@ -103,8 +104,8 @@ func taskDiff(path []string, old *pb.Task, new *pb.Task) []string {
 	sort.Strings(children)
 
 	for _, child := range children {
-		oldChild, _ := oldChildren[child]
-		newChild, _ := newChildren[child]
+		oldChild := oldChildren[child]
+		newChild := newChildren[child]
 		taskName := "(unknown)"
 		if newChild != nil {
 			taskName = newChild.Name
@@ -130,7 +131,8 @@ func (j *Job) Poll(ctx context.Context) {
 		log.Printf("State changed: %s\n", strings.Join(diff, "\n"))
 	}
 
-	j.oldProto = proto.Clone(newProto).(*pb.Task)
+	//j.oldProto = proto.Clone(newProto).(*pb.Task)
+	j.oldProto = newProto
 }
 
 func (j *Job) TaskRequest(r *pb.TaskRequest) error {

--- a/golang/pkg/rnr/job.go
+++ b/golang/pkg/rnr/job.go
@@ -131,7 +131,6 @@ func (j *Job) Poll(ctx context.Context) {
 		log.Printf("State changed: %s\n", strings.Join(diff, "\n"))
 	}
 
-	//j.oldProto = proto.Clone(newProto).(*pb.Task)
 	j.oldProto = newProto
 }
 

--- a/golang/pkg/rnr/task_async.go
+++ b/golang/pkg/rnr/task_async.go
@@ -6,32 +6,6 @@ import (
 	"github.com/mplzik/rnr/golang/pkg/pb"
 )
 
-// type AsyncFunc func(context.Context, *AsyncTask)
-
-// type AsyncTask struct {
-// 	pbMutex   sync.Mutex
-// 	pb        pb.Task
-// 	bgTask    AsyncFunc
-// 	parentCtx context.Context
-// 	ctx       context.Context
-// 	cancel    context.CancelFunc
-
-// 	// If set to `true`, the task will keep on running even after switching to SUCCESS state, making it a sort-of background task.
-// 	runsInSuccess bool
-// }
-
-// func NewAsyncTask(name string, ctx context.Context, runsInSuccess bool, bgTask AsyncFunc) *AsyncTask {
-// 	ret := &AsyncTask{}
-// 	ret.pb.Name = name
-// 	ret.bgTask = bgTask
-// 	ret.parentCtx = ctx
-// 	ret.ctx = nil
-// 	ret.cancel = nil
-// 	ret.runsInSuccess = runsInSuccess
-
-// 	return ret
-// }
-
 type AsyncFunc func(context.Context, func(StateUpdateCallback) *pb.Task)
 
 func NewAsyncTask(name string, ctx context.Context, runsInSuccess bool, bgTask AsyncFunc) *Task {

--- a/golang/pkg/rnr/task_async.go
+++ b/golang/pkg/rnr/task_async.go
@@ -2,72 +2,62 @@ package rnr
 
 import (
 	"context"
-	"sync"
 
 	"github.com/mplzik/rnr/golang/pkg/pb"
-	proto "google.golang.org/protobuf/proto"
 )
 
-type AsyncFunc func(context.Context, *AsyncTask)
+// type AsyncFunc func(context.Context, *AsyncTask)
 
-type AsyncTask struct {
-	pbMutex   sync.Mutex
-	pb        pb.Task
-	bgTask    AsyncFunc
-	parentCtx context.Context
-	ctx       context.Context
-	cancel    context.CancelFunc
+// type AsyncTask struct {
+// 	pbMutex   sync.Mutex
+// 	pb        pb.Task
+// 	bgTask    AsyncFunc
+// 	parentCtx context.Context
+// 	ctx       context.Context
+// 	cancel    context.CancelFunc
 
-	// If set to `true`, the task will keep on running even after switching to SUCCESS state, making it a sort-of background task.
-	runsInSuccess bool
-}
+// 	// If set to `true`, the task will keep on running even after switching to SUCCESS state, making it a sort-of background task.
+// 	runsInSuccess bool
+// }
 
-func NewAsyncTask(name string, ctx context.Context, runsInSuccess bool, bgTask AsyncFunc) *AsyncTask {
-	ret := &AsyncTask{}
-	ret.pb.Name = name
-	ret.bgTask = bgTask
-	ret.parentCtx = ctx
-	ret.ctx = nil
-	ret.cancel = nil
-	ret.runsInSuccess = runsInSuccess
+// func NewAsyncTask(name string, ctx context.Context, runsInSuccess bool, bgTask AsyncFunc) *AsyncTask {
+// 	ret := &AsyncTask{}
+// 	ret.pb.Name = name
+// 	ret.bgTask = bgTask
+// 	ret.parentCtx = ctx
+// 	ret.ctx = nil
+// 	ret.cancel = nil
+// 	ret.runsInSuccess = runsInSuccess
+
+// 	return ret
+// }
+
+type AsyncFunc func(context.Context, func(StateUpdateCallback) *pb.Task)
+
+func NewAsyncTask(name string, ctx context.Context, runsInSuccess bool, bgTask AsyncFunc) *Task {
+	parentCtx := ctx
+	var currentCtx context.Context
+	var cancel context.CancelFunc
+
+	ret := NewTask(name, false, func(ctx context.Context, task *Task) {
+		state := task.Proto(nil)
+
+		if state.State == pb.TaskState_RUNNING || (runsInSuccess && state.State == pb.TaskState_SUCCESS) {
+			if currentCtx == nil {
+				currentCtx, cancel = context.WithCancel(parentCtx)
+				go bgTask(currentCtx, func(cb StateUpdateCallback) *pb.Task {
+					return task.Proto(cb)
+				})
+			}
+		} else {
+			if currentCtx != nil {
+				cancel()
+				currentCtx = nil
+				cancel = nil
+			}
+		}
+
+	})
 
 	return ret
-}
-
-// Task is a generic interface for pollable tasks
-func (bt *AsyncTask) Poll() {
-	state := bt.Proto(nil)
-
-	if state.State == pb.TaskState_RUNNING || (bt.runsInSuccess && state.State == pb.TaskState_SUCCESS) {
-		if bt.ctx == nil {
-			bt.ctx, bt.cancel = context.WithCancel(bt.parentCtx)
-			go bt.bgTask(bt.ctx, bt)
-		}
-	} else {
-		if bt.ctx != nil {
-			bt.cancel()
-			bt.ctx = nil
-			bt.cancel = nil
-		}
-	}
-}
-
-func (bt *AsyncTask) Proto(updater func(*pb.Task)) *pb.Task {
-	bt.pbMutex.Lock()
-	defer bt.pbMutex.Unlock()
-
-	if updater != nil {
-		updater(&bt.pb)
-	}
-	ret := proto.Clone(&bt.pb).(*pb.Task)
-
-	return ret
-}
-
-func (bt *AsyncTask) SetState(state pb.TaskState) {
-	bt.Proto(func(pb *pb.Task) { pb.State = state })
-}
-
-func (bt *AsyncTask) GetChild(name string) Task {
-	return nil
 }

--- a/golang/pkg/rnr/task_async_test.go
+++ b/golang/pkg/rnr/task_async_test.go
@@ -12,14 +12,15 @@ const tick = 10 * time.Millisecond
 
 func TestAsyncTask_Lifecycle(t *testing.T) {
 	running := false
-	at := NewAsyncTask("Test async task", context.Background(), false, func(ctx context.Context, at *AsyncTask) {
+	at := NewAsyncTask("Test async task", context.Background(), false, func(ctx context.Context, update func(StateUpdateCallback) *pb.Task) {
 		running = true
 		select {
 		case <-ctx.Done():
 			running = false
 		}
-		at.Proto(func(t *pb.Task) {
+		update(func(t *pb.Task) *pb.Task {
 			t.State = pb.TaskState_SUCCESS
+			return t
 		})
 	})
 
@@ -29,8 +30,9 @@ func TestAsyncTask_Lifecycle(t *testing.T) {
 		t.Errorf("async task expected not running was found running")
 	}
 
-	at.Proto(func(t *pb.Task) {
+	at.Proto(func(t *pb.Task) *pb.Task {
 		t.State = pb.TaskState_RUNNING
+		return t
 	})
 	at.Poll()
 	time.Sleep(tick)
@@ -38,8 +40,9 @@ func TestAsyncTask_Lifecycle(t *testing.T) {
 		t.Errorf("async task expected running was found not running")
 	}
 
-	at.Proto(func(t *pb.Task) {
+	at.Proto(func(t *pb.Task) *pb.Task {
 		t.State = pb.TaskState_SUCCESS
+		return t
 	})
 	at.Poll()
 	time.Sleep(tick)
@@ -50,14 +53,15 @@ func TestAsyncTask_Lifecycle(t *testing.T) {
 
 func TestAsyncTask_BackgroundLifecycle(t *testing.T) {
 	running := false
-	at := NewAsyncTask("Test async task", context.Background(), true, func(ctx context.Context, at *AsyncTask) {
+	at := NewAsyncTask("Test async task", context.Background(), true, func(ctx context.Context, update func(StateUpdateCallback) *pb.Task) {
 		running = true
 		select {
 		case <-ctx.Done():
 			running = false
 		}
-		at.Proto(func(t *pb.Task) {
+		update(func(t *pb.Task) *pb.Task {
 			t.State = pb.TaskState_SUCCESS
+			return t
 		})
 	})
 
@@ -67,8 +71,9 @@ func TestAsyncTask_BackgroundLifecycle(t *testing.T) {
 		t.Errorf("async task expected not running was found running")
 	}
 
-	at.Proto(func(t *pb.Task) {
+	at.Proto(func(t *pb.Task) *pb.Task {
 		t.State = pb.TaskState_RUNNING
+		return t
 	})
 	at.Poll()
 	time.Sleep(tick)
@@ -76,8 +81,9 @@ func TestAsyncTask_BackgroundLifecycle(t *testing.T) {
 		t.Errorf("async task expected running was found not running")
 	}
 
-	at.Proto(func(t *pb.Task) {
+	at.Proto(func(t *pb.Task) *pb.Task {
 		t.State = pb.TaskState_SUCCESS
+		return t
 	})
 	at.Poll()
 	time.Sleep(tick)
@@ -85,8 +91,9 @@ func TestAsyncTask_BackgroundLifecycle(t *testing.T) {
 		t.Errorf("async task expected to be running in SUCCESS was found not running")
 	}
 
-	at.Proto(func(t *pb.Task) {
+	at.Proto(func(t *pb.Task) *pb.Task {
 		t.State = pb.TaskState_FAILED
+		return t
 	})
 	at.Poll()
 	time.Sleep(tick)
@@ -96,17 +103,19 @@ func TestAsyncTask_BackgroundLifecycle(t *testing.T) {
 }
 
 func TestAsyncTask_EarlyExit(t *testing.T) {
-	at := NewAsyncTask("Test async task", context.Background(), false, func(ctx context.Context, at *AsyncTask) {
+	at := NewAsyncTask("Test async task", context.Background(), false, func(context.Context, func(StateUpdateCallback) *pb.Task) {
 	})
 
-	at.Proto(func(t *pb.Task) {
+	at.Proto(func(t *pb.Task) *pb.Task {
 		t.State = pb.TaskState_RUNNING
+		return t
 	})
 	at.Poll()
 	time.Sleep(tick)
 
-	at.Proto(func(t *pb.Task) {
+	at.Proto(func(t *pb.Task) *pb.Task {
 		t.State = pb.TaskState_SUCCESS
+		return t
 	})
 	at.Poll()
 	time.Sleep(10 * time.Millisecond)

--- a/golang/pkg/rnr/task_shell.go
+++ b/golang/pkg/rnr/task_shell.go
@@ -1,79 +1,42 @@
 package rnr
 
 import (
+	"context"
 	"os/exec"
-	"sync"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/mplzik/rnr/golang/pkg/pb"
 )
 
-// Shell Task
+func NewShellTask(name, command string, args ...string) *Task {
+	cmd := exec.Command(command, args...)
+	err := make(chan error)
 
-type ShellTask struct {
-	pbMutex  sync.Mutex
-	pb       pb.Task
-	children []Task
-	cmdName  string
-	cmdArgs  []string
-	err      chan error
-
-	cmd *exec.Cmd
-}
-
-func NewShellTask(name, cmd string, args ...string) *ShellTask {
-	ret := &ShellTask{}
-
-	ret.pb.Name = name
-	ret.cmdName = cmd
-	ret.cmdArgs = args
-
-	ret.cmd = exec.Command(ret.cmdName, ret.cmdArgs...)
-	ret.err = make(chan error)
-
-	return ret
-}
-
-func (ct *ShellTask) Poll() {
-	if ct.cmd.Process == nil {
-		// Not yet started, let's launch it first
-		go func() { ct.err <- ct.cmd.Run() }()
-		ct.pb.Message = "Started"
-	}
-
-	select {
-	default:
-		// still running
-	case err := <-ct.err:
-		ct.pb.Message = "Exited"
-		// The process has finished
-		if err != nil {
-			ct.pb.State = pb.TaskState_FAILED
-			ct.pb.Message = err.Error()
-		} else {
-			ct.pb.State = pb.TaskState_SUCCESS
+	return NewTask(name, false, func(ctx context.Context, task *Task) {
+		if cmd.Process == nil {
+			// Not yet started, let's launch it first
+			go func() { err <- cmd.Run() }()
+			task.Proto(func(taskpb *pb.Task) *pb.Task {
+				taskpb.Message = "Started"
+				return taskpb
+			})
 		}
-	}
 
-	// TODO: if deemed safe, terminating the process while
-}
+		select {
+		default:
+			// still running
+		case err := <-err:
+			task.Proto(func(taskpb *pb.Task) *pb.Task {
+				taskpb.Message = "Exited"
+				// The process has finished
+				if err != nil {
+					taskpb.State = pb.TaskState_FAILED
+					taskpb.Message = err.Error()
+				} else {
+					taskpb.State = pb.TaskState_SUCCESS
+				}
+				return taskpb
+			})
+		}
 
-func (ct *ShellTask) Proto(updater func(*pb.Task)) *pb.Task {
-	ct.pbMutex.Lock()
-	defer ct.pbMutex.Unlock()
-
-	if updater != nil {
-		updater(&ct.pb)
-	}
-	ret := proto.Clone(&ct.pb).(*pb.Task)
-
-	return ret
-}
-
-func (nt *ShellTask) SetState(state pb.TaskState) {
-	nt.Proto(func(pb *pb.Task) { pb.State = state })
-}
-
-func (nt *ShellTask) GetChild(name string) Task {
-	return nil
+	})
 }

--- a/golang/pkg/rnr/task_simple_callback.go
+++ b/golang/pkg/rnr/task_simple_callback.go
@@ -2,79 +2,26 @@ package rnr
 
 import (
 	"context"
-	"sync"
-	"time"
 
 	"github.com/mplzik/rnr/golang/pkg/pb"
-	"google.golang.org/protobuf/proto"
 )
 
-type CallbackFunc func(context.Context, *CallbackTask) (bool, error)
-
-// CallbackTask
-
-// CallbackTask implements a task with synchronously called callback.
-// It returns a boolean indicating whether to transition into a final state and an error in case an error has happened. These values are used to best-effort-update the task's protobuf. If (false, nil) is supplied, the task state will be left untouched
-type CallbackTask struct {
-	pbMutex  sync.Mutex
-	pb       pb.Task
-	oldState pb.TaskState
-	callback CallbackFunc
-}
+type CallbackFunc func(context.Context, *pb.Task) *pb.Task
 
 // NewCallbackTask returns a new callback task.
-func NewCallbackTask(name string, callback CallbackFunc) *CallbackTask {
-	ret := &CallbackTask{}
+func NewCallbackTask(name string, callback CallbackFunc) *Task {
 
-	ret.pb.Name = name
-	ret.callback = callback
-	ret.oldState = pb.TaskState_UNKNOWN
+	newTask := NewTask(name, false, func(ctx context.Context, task *Task) {
+		var oldState = pb.TaskState_PENDING
+		task.Proto(func(taskState *pb.Task) *pb.Task {
+			if (taskState.State != pb.TaskState_RUNNING) && (oldState == taskState.State) {
+				return taskState
+			}
 
-	return ret
-}
+			oldState = taskState.State
+			return callback(ctx, taskState)
+		})
+	})
 
-// Poll synchronously calls the callback
-func (ct *CallbackTask) Poll() {
-	if (taskSchedState(&ct.pb) != RUNNING) && (ct.oldState == ct.pb.GetState()) {
-		return
-	}
-
-	ct.oldState = ct.pb.GetState()
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-
-	ret, err := ct.callback(ctx, ct)
-
-	if ret {
-		if err == nil {
-			ct.pb.State = pb.TaskState_SUCCESS
-		} else {
-			ct.pb.State = pb.TaskState_FAILED
-			ct.pb.Message = err.Error()
-		}
-	} else {
-		if err != nil {
-			ct.pb.Message = err.Error()
-		}
-	}
-}
-
-func (ct *CallbackTask) Proto(updater func(*pb.Task)) *pb.Task {
-	ct.pbMutex.Lock()
-	defer ct.pbMutex.Unlock()
-
-	if updater != nil {
-		updater(&ct.pb)
-	}
-	ret := proto.Clone(&ct.pb).(*pb.Task)
-
-	return ret
-}
-
-func (ct *CallbackTask) SetState(state pb.TaskState) {
-	ct.Proto(func(pb *pb.Task) { pb.State = state })
-}
-
-func (ct *CallbackTask) GetChild(name string) Task {
-	return nil
+	return newTask
 }

--- a/golang/pkg/rnr/tasks.go
+++ b/golang/pkg/rnr/tasks.go
@@ -57,8 +57,8 @@ func NewTask(name string, children bool, cb TaskCallback) *Task {
 	}
 }
 
-func (task *Task) Poll() {
-	task.cb(context.TODO(), task)
+func (task *Task) Poll(ctx context.Context) {
+	task.cb(ctx, task)
 }
 
 func (task *Task) Proto(updater StateUpdateCallback) *pb.Task {

--- a/golang/pkg/rnr/tasks.go
+++ b/golang/pkg/rnr/tasks.go
@@ -1,7 +1,12 @@
 package rnr
 
 import (
+	"context"
+	"fmt"
+	"log"
+
 	"github.com/mplzik/rnr/golang/pkg/pb"
+	proto "google.golang.org/protobuf/proto"
 )
 
 type TaskState int
@@ -28,10 +33,84 @@ func taskSchedState(pbt *pb.Task) TaskState {
 	return UNKNOWN
 }
 
+// TaskCallback is installed by higher-level construct, such as callback task or nested task.
+type TaskCallback func(context.Context, *Task)
+type StateUpdateCallback func(*pb.Task) *pb.Task
+
 // Task is a generic interface for pollable tasks
-type Task interface {
-	Poll()
-	Proto(updater func(*pb.Task)) *pb.Task
-	SetState(pb.TaskState)
-	GetChild(name string) Task
+type Task struct {
+	cb           TaskCallback
+	pb           *pb.Task
+	children     []*Task
+	has_children bool
+}
+
+func NewTask(name string, children bool, cb TaskCallback) *Task {
+	return &Task{
+		cb: cb,
+		pb: &pb.Task{
+			Name:  name,
+			State: pb.TaskState_PENDING,
+		},
+		children:     []*Task{},
+		has_children: children,
+	}
+}
+
+func (task *Task) Poll() {
+	task.cb(context.TODO(), task)
+}
+
+func (task *Task) Proto(updater StateUpdateCallback) *pb.Task {
+
+	oldState, ok := proto.Clone(task.pb).(*pb.Task)
+	if !ok {
+		log.Fatalf("Failed to clone proto")
+	}
+
+	if updater != nil {
+		task.pb = updater(oldState)
+	}
+
+	// Rebuild the children protobufs.
+	// This is terribly inefficient, but probably the easiest thing to do.
+	task.pb.Children = []*pb.Task{}
+	for _, c := range task.children {
+		p := c.Proto(nil)
+		task.pb.Children = append(task.pb.Children, p)
+	}
+
+	return task.pb
+}
+
+// SetState is a shortcut for atomically setting a state in the proto
+func (task *Task) SetState(state pb.TaskState) {
+	task.Proto(func(pb *pb.Task) *pb.Task {
+		pb.State = state
+		return pb
+	})
+}
+
+// GetChild returns a child with the specified name
+func (task *Task) GetChild(name string) *Task {
+	for _, c := range task.children {
+		if c.pb.Name == name {
+			return c
+		}
+	}
+
+	return nil
+}
+
+func (nt *Task) Add(task *Task) error {
+	newName := task.Proto(nil).Name
+
+	for _, child := range nt.children {
+		if child.Proto(nil).Name == newName {
+			return fmt.Errorf("task named '%s' already exists", child.Proto(nil).Name)
+		}
+	}
+	nt.children = append(nt.children, task)
+
+	return nil
 }

--- a/golang/pkg/rnr/tasks.go
+++ b/golang/pkg/rnr/tasks.go
@@ -2,6 +2,7 @@ package rnr
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 
@@ -17,6 +18,8 @@ const (
 	RUNNING
 	DONE
 )
+
+var ErrNoChildrenAllowed = errors.New("no children allowed for this kind of task")
 
 func taskSchedState(pbt *pb.Task) TaskState {
 	switch pbt.State {
@@ -102,6 +105,10 @@ func (task *Task) GetChild(name string) *Task {
 }
 
 func (nt *Task) Add(task *Task) error {
+	if nt.has_children {
+		return ErrNoChildrenAllowed
+	}
+
 	newName := task.Proto(nil).Name
 
 	for _, child := range nt.children {

--- a/golang/pkg/rnr/tasks.go
+++ b/golang/pkg/rnr/tasks.go
@@ -74,10 +74,9 @@ func (task *Task) Proto(updater StateUpdateCallback) *pb.Task {
 
 	// Rebuild the children protobufs.
 	// This is terribly inefficient, but probably the easiest thing to do.
-	task.pb.Children = []*pb.Task{}
-	for _, c := range task.children {
-		p := c.Proto(nil)
-		task.pb.Children = append(task.pb.Children, p)
+	task.pb.Children = make([]*pb.Task, len(task.children))
+	for i, c := range task.children {
+		task.pb.Children[i] = c.Proto(nil)
 	}
 
 	return task.pb


### PR DESCRIPTION
This PR attempts to reduce few frequent `rnr` pain points:

- A lot of code was duplicated each time a new type of Task was
  introduced, even though most were copy/paste implementations. This has
  now changed and `Task` is a full-fledged struct instead of interface.
- Any tasks are now built on top of `Task` by implementing their own
  callback function.
- The `CallbackTask` callback function signature got changed and now it
  receives a state proto and returns a state proto.
- The AsyncTask now gets an argument that it can call to update protobuf
  state.

Other than that, lots of fixing and cleanups.

Signed-off-by: Milan Plzik <milan.plzik@grafana.com>
